### PR TITLE
Add linter check for form yb defs

### DIFF
--- a/src/lint/typedefs_list.sh
+++ b/src/lint/typedefs_list.sh
@@ -25,6 +25,20 @@ if [[ "$1" == */yb_typedefs.list ]]; then
   grep -Env "$pattern" "$1" \
     | sed 's/^/error:missing_yb_in_type_name:'\
 'Types in yb_typedefs.list should have "yb":/'
+
+  grep -o 'Form_[a-zA-Z0-9_]*' "$1" | while read -r form; do
+    formdata="FormData_${form#Form_}"
+    if ! grep -q "^$formdata$" "$1"; then
+      echo "error:missing_FormData:$formdata is missing for $form"
+    fi
+  done
+  
+  grep -o 'FormData_[a-zA-Z0-9_]*' "$1" | while read -r formdata; do
+    form="Form_${formdata#FormData_}"
+    if ! grep -q "^$form$" "$1"; then
+      echo "error:missing_Form:$form is missing for $formdata"
+    fi
+  done
 else
   grep -En "$pattern" "$1" \
     | sed 's/^/error:bad_yb_in_type_name:'\

--- a/src/lint/typedefs_list.sh
+++ b/src/lint/typedefs_list.sh
@@ -26,19 +26,34 @@ if [[ "$1" == */yb_typedefs.list ]]; then
     | sed 's/^/error:missing_yb_in_type_name:'\
 'Types in yb_typedefs.list should have "yb":/'
 
-  grep -o 'Form_[a-zA-Z0-9_]*' "$1" | while read -r form; do
+  grep -no '^Form_[a-zA-Z0-9_]*' "$1" \
+    | while IFS=: read -r lineno form; do
     formdata="FormData_${form#Form_}"
     if ! grep -q "^$formdata$" "$1"; then
-      echo "error:missing_FormData:$formdata is missing for $form"
+      echo "error:missing_formdata:$formdata is missing for $form:$lineno:"
+    fi
+  done
+
+  grep -no '^FormData_[a-zA-Z0-9_]*' "$1" \
+    | while IFS=: read -r lineno formdata; do
+    form="Form_${formdata#FormData_}"
+    if ! grep -q "^$form$" "$1"; then
+      echo "error:missing_form:$form is missing for $formdata:$lineno:"
     fi
   done
   
-  grep -o 'FormData_[a-zA-Z0-9_]*' "$1" | while read -r formdata; do
-    form="Form_${formdata#FormData_}"
-    if ! grep -q "^$form$" "$1"; then
-      echo "error:missing_Form:$form is missing for $formdata"
-    fi
-  done
+  # Find all header files in pggate that contain YB_DEFINE_HANDLE_TYPE
+  git grep -l YB_DEFINE_HANDLE_TYPE src/yb/yql/pggate | \
+    # Extract the handle type names
+    xargs grep -ho 'YB_DEFINE_HANDLE_TYPE([A-Z][a-zA-Z0-9_]*)' | \
+    # Remove the macro name and parentheses
+    sed 's/YB_DEFINE_HANDLE_TYPE(//' | sed 's/)//' | sort -u | while read -r handle_type; do
+      transformed_type="Ybc${handle_type}"
+      if ! grep -q "^$transformed_type$" "$1"; then
+        echo "error:missing_handle_type:Missing $transformed_type \
+for YB_DEFINE_HANDLE_TYPE($handle_type):1:"
+      fi
+    done
 else
   grep -En "$pattern" "$1" \
     | sed 's/^/error:bad_yb_in_type_name:'\


### PR DESCRIPTION
### Summary
- Update the linting shell script so that we check if the corresponding `FormData*` definition is available and vice-versa. 
- YB_DEFINE_HANDLE_TYPE() also needs a neccessary transform, check for that

## Summary by Sourcery

Add lint checks for Form/FormData pairs and handle type transformations

Enhancements:
- Validate that each Form_* type in yb_typedefs.list has a corresponding FormData_* entry and vice versa
- Ensure YB_DEFINE_HANDLE_TYPE macros correspond to Ybc-prefixed types in yb_typedefs.list